### PR TITLE
Implementing a `remove_wait` and `remove`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 smallvec = "1.2.0"
-dashmap = "3.7.0"
+dashmap = "5.3.4"
 
 [dev-dependencies.async-std]
 version = "1.5.0"

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -1,0 +1,98 @@
+use std::borrow::Borrow;
+use std::future::Future;
+use std::hash::{BuildHasher, Hash};
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::task::{Context, Poll};
+use dashmap::DashMap;
+use crate::{Filled, WaitEntry, Waiting};
+
+/// A Future created by `WaitMap::remove_wait`. The future resolves to the the (Key, Value) as a
+/// move when the value is available.
+pub struct Remove<'a, 'b, K, V, S, Q> where K: Hash + Eq + Borrow<Q>,
+                                            S: BuildHasher + Clone,
+                                            Q: ?Sized + Hash + Eq, {
+    // We need the mutex here because we *will* be modifying the map, it's possible that some one is
+    // checking the variant of the entry while we're removing it! It might make more sense if you
+    // look at the Future impl.
+    map: Mutex<&'a DashMap<K, WaitEntry<V>, S>>,
+    key: &'b Q,
+
+    /// The index of the waker in the waker set.
+    /// Note:
+    /// If the index is `usize::MAX`, then the waker is not in the set.
+    idx: usize,
+}
+
+impl<'a, 'b, K, V, S, Q> Remove<'a, 'b, K, V, S, Q> where K: Hash + Eq + Borrow<Q>,
+                                                          S: BuildHasher + Clone,
+                                                          Q: ?Sized + Hash + Eq, {
+    pub(crate) fn new(map: &'a DashMap<K, WaitEntry<V>, S>, key: &'b Q) -> Self {
+        Remove {
+            map: Mutex::new(map),
+            key,
+            idx: usize::MAX,
+        }
+    }
+}
+
+impl<'a, 'b, K, V, S, Q> Future for Remove<'a, 'b, K, V, S, Q> where K: Hash + Eq + Borrow<Q>,
+                                                                     S: BuildHasher + Clone,
+                                                                     Q: ?Sized + Hash + Eq, {
+    type Output = Option<(K, V)>;
+    fn poll(self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
+        // we need to hold an exclusive lock since some one might be checking the variant of the entry
+        // while we're removing it!
+        let this = self.get_mut();
+        let map = this.map.lock().unwrap();
+        let remove;
+
+        // we need to drop the reference returned by `get_mut` to prevent a dead lock
+        {
+            match map.get_mut(this.key) {
+                Some(mut entry) => match entry.value_mut() {
+                    Waiting(wakers) => {
+                        wakers.replace(ctx.waker().clone(), &mut this.idx);
+                        return Poll::Pending;
+                    }
+                    Filled(_) => remove = true
+                },
+                None => return Poll::Ready(None)
+            };
+        }
+
+        if remove {
+            match map.remove(this.key) {
+                Some((key, wait_entry)) => {
+                    eprintln!("removed successfully");
+                    this.idx = usize::MAX;
+                    let value = match wait_entry {
+                        Filled(value) => value,
+                        Waiting(_) => unreachable!("we should not be here if the entry is waiting")
+                    };
+                    Poll::Ready(Some((key, value)))
+                }
+                None => {
+                    Poll::Ready(None)
+                }
+            }
+        } else {
+            unreachable!("we should not be here if remove is never set")
+        }
+    }
+}
+
+impl<'a, 'b, K, V, S, Q> Drop for Remove<'a, 'b, K, V, S, Q> where
+    K: Hash + Eq + Borrow<Q>,
+    S: BuildHasher + Clone,
+    Q: ?Sized + Hash + Eq,
+{
+    fn drop(&mut self) {
+        if self.idx == usize::MAX { return; }
+        if let Some(mut entry) = self.map.lock().unwrap().get_mut(self.key) {
+            if let Waiting(wakers) = entry.value_mut() {
+                wakers.remove(self.idx);
+            }
+        }
+    }
+}

--- a/src/wait.rs
+++ b/src/wait.rs
@@ -26,7 +26,7 @@ impl<'a, 'b, K, V, S, Q> Wait<'a, 'b, K, V, S, Q> where
     Q: ?Sized + Hash + Eq,
 {
     pub(crate) fn new(map: &'a DashMap<K, WaitEntry<V>, S>, key: &'b Q) -> Self {
-        Wait { map, key, idx: std::usize::MAX }
+        Wait { map, key, idx: usize::MAX }
     }
 }
 
@@ -46,7 +46,7 @@ impl<'a, 'b, K, V, S, Q> Future for Wait<'a, 'b, K, V, S, Q> where
                 }
                 Filled(_)        => {
                     let inner = entry.downgrade();
-                    self.idx = std::usize::MAX;
+                    self.idx = usize::MAX;
                     Poll::Ready(Some(Ref { inner }))
                 }
             }
@@ -61,7 +61,7 @@ impl<'a, 'b, K, V, S, Q> Drop for Wait<'a, 'b, K, V, S, Q> where
     Q: ?Sized + Hash + Eq,
 {
     fn drop(&mut self) {
-        if self.idx == std::usize::MAX { return; }
+        if self.idx == usize::MAX { return; }
         if let Some(mut entry) = self.map.get_mut(self.key) {
             if let Waiting(wakers) = entry.value_mut() {
                 wakers.remove(self.idx);
@@ -86,7 +86,7 @@ impl<'a, 'b, K, V, S, Q> WaitMut<'a, 'b, K, V, S, Q> where
     Q: ?Sized + Hash + Eq,
 {
     pub(crate) fn new(map: &'a DashMap<K, WaitEntry<V>, S>, key: &'b Q) -> Self {
-        WaitMut { map, key, idx: std::usize::MAX }
+        WaitMut { map, key, idx: usize::MAX }
     }
 }
 
@@ -105,7 +105,7 @@ impl<'a, 'b, K, V, S, Q> Future for WaitMut<'a, 'b, K, V, S, Q> where
                     Poll::Pending
                 }
                 Filled(_)        => {
-                    self.idx = std::usize::MAX;
+                    self.idx = usize::MAX;
                     Poll::Ready(Some(RefMut { inner: entry }))
                 }
             }
@@ -120,7 +120,7 @@ impl<'a, 'b, K, V, S, Q> Drop for WaitMut<'a, 'b, K, V, S, Q> where
     Q: ?Sized + Hash + Eq,
 {
     fn drop(&mut self) {
-        if self.idx == std::usize::MAX { return; }
+        if self.idx == usize::MAX { return; }
         if let Some(mut entry) = self.map.get_mut(self.key) {
             if let Waiting(wakers) = entry.value_mut() {
                 wakers.remove(self.idx);

--- a/src/waker_set.rs
+++ b/src/waker_set.rs
@@ -16,7 +16,7 @@ impl WakerSet {
     pub fn replace(&mut self, waker: Waker, idx: &mut usize) {
         let len = self.wakers.len();
         if *idx >= len {
-            debug_assert!(len != std::usize::MAX); // usize::MAX is used as a sentinel
+            debug_assert!(len != usize::MAX); // usize::MAX is used as a sentinel
             *idx = len;
             self.wakers.push(Some(waker));
         } else {

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use waitmap::WaitMap;
 
 use async_std::task;
+use async_std::task::sleep;
 
 #[test]
 fn works_like_a_normal_map() {
@@ -98,4 +99,73 @@ fn multiple_tasks_can_wait_one_key() {
 
     task::block_on(handle1);
     task::block_on(handle2);
+}
+
+#[test]
+fn single_remove_works_like_normal_maps() {
+    let test = async {
+        let map = WaitMap::new();
+        map.insert(String::from("Rosa Luxemburg"), 0);
+
+        let rosa = map.remove_wait("Rosa Luxemburg").await;
+        assert_eq!(rosa.unwrap(), (String::from("Rosa Luxemburg"), 0));
+    };
+
+    task::block_on(test);
+}
+
+
+#[test]
+fn only_one_remove_gets_value() {
+    let map: Arc<WaitMap<String, i32>> = Arc::new(WaitMap::new());
+    let map1 = map.clone();
+    let map2 = map.clone();
+    let map3 = map.clone();
+    let map4 = map.clone();
+
+
+    let handle1 = task::spawn(async move { map1.remove_wait("Rosa Luxemburg").await });
+    let handle2 = task::spawn(async move { map2.remove_wait("Rosa Luxemburg").await });
+    let handle3 = task::spawn(async move { map3.remove_wait("Rosa Luxemburg").await });
+    let handle4 = task::spawn(async move { map4.remove_wait("Rosa Luxemburg").await });
+
+
+    task::block_on(async move {
+        sleep(Duration::from_millis(140)).await;
+        map.insert(String::from("Rosa Luxemburg"), 0);
+    });
+
+    let returned = task::block_on(async move {
+        let remove1 = handle1.await;
+        let remove2 = handle2.await;
+        let remove3 = handle3.await;
+        let remove4 = handle4.await;
+
+        vec![remove1, remove2, remove3, remove4]
+    });
+
+    // we don't particularly care which one beat the rest and go the value, but there must be one
+    // all the rest are None
+    let some_count = returned
+        .iter()
+        .filter(|o| o.is_some())
+        .count();
+    assert_eq!(some_count, 1);
+
+    // and the None count better be total - 1
+    let none_count = returned
+        .iter()
+        .filter(|r| r.is_none())
+        .count();
+    assert_eq!(none_count, returned.len() - 1);
+
+    // and let's makes sure the one that beat the beat actually got the value
+    let (key, value) = returned
+        .into_iter()
+        .filter(|r| r.is_some())
+        .next()
+        .expect("there should be one Some")
+        .expect("the Some should have a value");
+
+    assert_eq!((key, value), (String::from("Rosa Luxemburg"), 0));
 }


### PR DESCRIPTION
Currently, the hashmap never shrinks. Obviously that's not ideal.

Moreover, there is no way to get the value out of the hashmap, only references out.

I am proposing two features, `remove_wait` and `remove`. 

# `remove`
This works just like a normal remove, except it cancels all pending waits at the same time.

# `remove_wait`
This is a bit exotic, my envisioned use case is someone knowing a key will become available in the future but it's not available now, so they wait for the key value pair to become avaialble. Admittedly, you could probably do this with channels but this provides a convenient way to refer to data in the future by an id/key. 

An example adapted from the test case might be

```rust
    let map: Arc<WaitMap<String, i32>> = Arc::new(WaitMap::new());
    let map1 = map.clone();
    let map2 = map.clone();

    let handle1 = task::spawn(async move { map1.remove_wait("Rosa Luxemburg").await });
    let handle2 = task::spawn(async move { map2.remove_wait("Rosa Luxemburg").await });

    task::block_on(async move {
        // make sure we only place the data after all the tasks interested have enqueued themselves
        // otherwise, instead of getting a `None`, they might be waiting for the next time the key is populated
        sleep(Duration::from_millis(140)).await;
        map.insert(String::from("Rosa Luxemburg"), 0)
    });
    
    // one of them will contain the key value pair, the other one will be none
    // the order is not guaranteed   
    let (kv1, kv2) = join!(handle1, handle2);
   
```